### PR TITLE
Update contact references

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   theme: "craftdocs",
   themeConfig: {
-    repo: "workingconcept/snipcart-docs",
+    repo: "FosterCommerce/snipcart-docs",
     docsBranch: "master",
     docsDir: "docs",
     editLinks: true,
@@ -132,8 +132,8 @@ module.exports = {
     ],
     nav: [
       {
-        text: "Working Concept",
-        link: "https://workingconcept.com/plugins/snipcart",
+        text: "Foster Commerce",
+        link: "https://www.fostercommerce.com/software",
       },
     ],
   },

--- a/docs/troubleshooting/getting-help.md
+++ b/docs/troubleshooting/getting-help.md
@@ -6,9 +6,9 @@ meta:
 
 # Getting Help
 
-- Email [support@workingconcept.com](mailto:support@workingconcept.com).
+- Email [support@fostercommerce.com](mailto:support@fostercommerce.com).
 - Post to the [Craft CMS Stack Exchange site](https://craftcms.stackexchange.com/) with a `plugin-snipcart` tag.
-- File a [GitHub Issue](https://github.com/workingconcept/snipcart-craft-plugin/issues) or [pull request](https://github.com/workingconcept/snipcart-craft-plugin/pulls).
-- Submit a support request [at workingconcept.com](https://workingconcept.com/plugins/snipcart/support).
-- Find [@mattrambles on Twitter](https://twitter.com/mattrambles) or @mattts (Matt Stein) [on Discord](https://craftcms.com/blog/discord).
+- File a [GitHub Issue](https://github.com/FosterCommerce/snipcart-craft-plugin/issues) or [pull request](https://github.com/FosterCommerce/snipcart-craft-plugin/pulls).
+- Submit a support request [from fostercommerce.com](https://www.fostercommerce.com/software).
+- Find [@fostercommerce on Twitter](https://twitter.com/fostercommerce).
 - Reach out to Snipcart from their control panel or [contact form](https://snipcart.com/contact-feedback).


### PR DESCRIPTION
Hi! :wave:

This updates a few old Working Concept references for the docs.

There are two more places with references I can’t update:

1. The docs repository link
    <img src="https://user-images.githubusercontent.com/2488775/116264891-427a7800-a740-11eb-8169-6cec76277a3c.png" width="300" />
2. A few parts of the [plugin store description](https://plugins.craftcms.com/snipcart)
    - “test project”
    - “for getting started”
    - “real time webhook Events”
